### PR TITLE
Add Team ID support and IPv6/AAAA record handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,44 @@ CMD ["bash", "/root/start.sh"]
 # Performs the first sync and starts CRON
 bash /root/dns-sync.sh && crond -f
 ```
+
+## AAAA Records
+
+The script can be modified to work with IPv6 addresses and AAAA records.
+
+Make the following changes to `dns-sync.sh`:
+
+1. Change line 17 to `  ip=$(curl -6 -s https://ifconfig.co)`
+2. On line 30, change `\"A\"` to `\"AAAA\"`
+3. On lines 51 and 75, change `"A"` to `"AAAA"`
+
+If using Docker, you will also need to:
+
+1. Make a local copy of `dns-sync.sh` with the above modifications, as well as `start.sh` and `dns.config`.
+2. Use the Dockerfile below.
+3. Enable host networking via `--network=host` or `network_mode: host`.
+
+This Dockerfile pulls a local version of dns-sync.sh
+```dockerfile
+FROM alpine:latest
+
+WORKDIR /root
+
+# Installing dependencies
+RUN apk --no-cache add dcron curl jq bash
+SHELL ["/bin/bash", "-c"]
+
+# Cloning config and start file
+COPY dns.config /root/dns.config
+COPY start.sh /root/start.sh
+COPY dns-sync.sh /root/dns-sync.sh
+
+# Make the main script executable
+RUN chmod +x /root/dns-sync.sh
+
+# Setting up cron to run every minute
+RUN echo "* * * * * /root/dns-sync.sh >> /var/log/dns-sync.log 2>&1" >> /etc/crontabs/root
+
+# Starting
+CMD ["bash", "/root/start.sh"]
+```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Simple script for exposing a local server with [Vercel DNS](https://vercel.com/docs/custom-domains).
 It runs on CRON, checking the current IP address and updating DNS records for your domain.
 
+This fork has been modified to:
+* Work with accounts that have Team IDs
+* Distinguish A from AAAA records
+
 ## Installation
 
 1. Ensure that you have [jq](https://github.com/jqlang/jq) installed
@@ -54,11 +58,11 @@ COPY dns.config /root/dns.config
 COPY start.sh /root/start.sh
 
 # Cloning app
-RUN curl -o /root/dns-sync.sh https://raw.githubusercontent.com/iam-medvedev/vercel-ddns/master/dns-sync.sh
+RUN curl -o /root/dns-sync.sh https://raw.github.com/ohshitgorillas/vercel-ddns/master/dns-sync.sh
 RUN chmod +x /root/dns-sync.sh
 
-# Setting up cron
-RUN echo "*/30 * * * * /root/dns-sync.sh >> /var/log/dns-sync.log 2>&1" >> /etc/crontabs/root
+# Setting up cron to run every minute
+RUN echo "* * * * * /root/dns-sync.sh >> /var/log/dns-sync.log 2>&1" >> /etc/crontabs/root
 
 # Starting
 CMD ["bash", "/root/start.sh"]

--- a/dns-sync.sh
+++ b/dns-sync.sh
@@ -3,7 +3,7 @@
 # Vercel Dynamic DNS
 # https://github.com/iam-medvedev/vercel-ddns
 
-source ./dns.config
+source /root/dns.config
 
 # Check if jq is installed
 if ! command -v jq >/dev/null; then
@@ -22,12 +22,12 @@ get_current_ip() {
 check_subdomain_exists() {
   local subdomain="$1"
   local response
-  response=$(curl -sX GET "https://api.vercel.com/v4/domains/$DOMAIN_NAME/records" \
+  response=$(curl -sX GET "https://api.vercel.com/v4/domains/$DOMAIN_NAME/records?teamId=$TEAM_ID" \
     -H "Authorization: Bearer $VERCEL_TOKEN" \
     -H "Content-Type: application/json")
 
   local record_id
-  record_id=$(echo "$response" | jq -r ".records[] | select(.name == \"$subdomain\") | .id")
+  record_id=$(echo "$response" | jq -r ".records[] | select(.name == \"$subdomain\" and .type == \"A\") | .id")
   if [[ -n "$record_id" ]]; then
     # Return record ID if exists
     echo "$record_id"
@@ -42,7 +42,7 @@ update_dns_record() {
   local ip="$1"
   local record_id="$2"
   local response
-  response=$(curl -sX PATCH "https://api.vercel.com/v1/domains/records/$record_id" \
+  response=$(curl -sX PATCH "https://api.vercel.com/v1/domains/records/$record_id?teamId=$TEAM_ID" \
     -H "Authorization: Bearer $VERCEL_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{
@@ -66,7 +66,7 @@ update_dns_record() {
 create_dns_record() {
   local ip="$1"
   local response
-  response=$(curl -sX POST "https://api.vercel.com/v4/domains/$DOMAIN_NAME/records" \
+  response=$(curl -sX POST "https://api.vercel.com/v4/domains/$DOMAIN_NAME/records?teamId=$TEAM_ID" \
     -H "Authorization: Bearer $VERCEL_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{

--- a/dns-sync.sh
+++ b/dns-sync.sh
@@ -11,10 +11,14 @@ if ! command -v jq >/dev/null; then
   exit 1
 fi
 
-# Returns current IP
+# Returns current IP (IPv4 for A records, IPv6 for AAAA records)
 get_current_ip() {
   local ip
-  ip=$(curl -s http://whatismyip.akamai.com/)
+  if [[ "$RECORD_TYPE" == "AAAA" ]]; then
+    ip=$(curl -s https://api6.ipify.org)
+  else
+    ip=$(curl -s http://whatismyip.akamai.com/)
+  fi
   echo $ip
 }
 
@@ -27,7 +31,7 @@ check_subdomain_exists() {
     -H "Content-Type: application/json")
 
   local record_id
-  record_id=$(echo "$response" | jq -r ".records[] | select(.name == \"$subdomain\" and .type == \"A\") | .id")
+  record_id=$(echo "$response" | jq -r ".records[] | select(.name == \"$subdomain\" and .type == \"$RECORD_TYPE\") | .id")
   if [[ -n "$record_id" ]]; then
     # Return record ID if exists
     echo "$record_id"
@@ -48,7 +52,7 @@ update_dns_record() {
     -d '{
       "comment": "vercel-ddns",
       "name": "'$SUBDOMAIN'",
-      "type": "A",
+      "type": "'$RECORD_TYPE'",
       "value": "'$ip'",
       "ttl": 60
     }')
@@ -72,7 +76,7 @@ create_dns_record() {
     -d '{
       "comment": "vercel-ddns",
       "name": "'$SUBDOMAIN'",
-      "type": "A",
+      "type": "'$RECORD_TYPE'",
       "value": "'$ip'",
       "ttl": 60
     }')

--- a/dns.config.example
+++ b/dns.config.example
@@ -11,3 +11,6 @@ SUBDOMAIN=""
 
 # Team ID (Vercel Dashboard > Settings)
 TEAM_ID=""
+
+# Record type: "A" for IPv4, "AAAA" for IPv6 (default: A)
+RECORD_TYPE="A"

--- a/dns.config.example
+++ b/dns.config.example
@@ -8,3 +8,6 @@ DOMAIN_NAME=""
 
 # Subdomain to update (note: use an empty string for the root record)
 SUBDOMAIN=""
+
+# Team ID (Vercel Dashboard > Settings)
+TEAM_ID=""


### PR DESCRIPTION
## Summary
This PR adds support for Vercel accounts with Team IDs and enables handling of both IPv4 (A) and IPv6 (AAAA) DNS records. The script now allows users to configure which record type to update and properly includes team context in API requests.

## Key Changes
- **Team ID Support**: Added `TEAM_ID` configuration parameter and included it in all Vercel API requests (`teamId` query parameter)
- **IPv6/AAAA Records**: Added `RECORD_TYPE` configuration option to distinguish between A (IPv4) and AAAA (IPv6) records
  - Updated IP detection logic to use appropriate service based on record type (IPv4 vs IPv6)
  - Modified DNS record filtering to match both subdomain name and record type
  - Updated all API calls to use the configured record type instead of hardcoded "A"
- **Configuration**: Extended `dns.config.example` with new `TEAM_ID` and `RECORD_TYPE` parameters
- **Docker**: Updated cron schedule from every 30 minutes to every minute and changed script source URL
- **Documentation**: Added comprehensive instructions for IPv6 setup and example Dockerfile for local script deployment

## Implementation Details
- IP detection now conditionally calls IPv6 API (`api6.ipify.org`) when `RECORD_TYPE` is "AAAA", otherwise uses existing IPv4 service
- DNS record lookup filters by both `name` and `type` to avoid conflicts between A and AAAA records for the same subdomain
- All Vercel API endpoints now include `teamId` query parameter when making requests
- Configuration file path updated to absolute path (`/root/dns.config`) for better Docker compatibility

https://claude.ai/code/session_01R9g5mpTL36sKwdRYc1gst7